### PR TITLE
free strings in test

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -915,6 +915,7 @@ int main(void) {
         y = sdscatrepr(sdsempty(),x,sdslen(x));
         test_cond("sdscatrepr(...data...)",
             memcmp(y,"\"\\a\\n\\x00foo\\r\"",15) == 0)
+	sdsfree(y);
 
         {
             int oldfree;
@@ -932,6 +933,7 @@ int main(void) {
             test_cond("sdsIncrLen() -- content", x[0] == '0' && x[1] == '1');
             test_cond("sdsIncrLen() -- len", sh->len == 2);
             test_cond("sdsIncrLen() -- free", sh->free == oldfree-1);
+	    sdsfree(x);
         }
 
         x = sdsnew("0FoO1bar\n");


### PR DESCRIPTION
valgrind reported sdsMakeRoomFor leaking some bytes but it was just the
test cases not freeing strings.

This is the same as pull request #42 on antirez/sds, but lemzwerg seems to be collecting community patches, so here you go
